### PR TITLE
#13 Short or long course standards qualifies for short or long course championships

### DIFF
--- a/swimmers/controller.go
+++ b/swimmers/controller.go
@@ -52,7 +52,7 @@ func (sc *SwimmersController) BenchmarkTime(res http.ResponseWriter, req *http.R
 	stroke := event[1]
 
 	var foundMeets []*Meet
-	meets, err := FindChampionshipMeets(course, sc.DB)
+	meets, err := FindChampionshipMeets(sc.DB)
 	if err != nil {
 		log.Printf("swimmers.FindChampionshipMeets: %v", err)
 	}
@@ -72,7 +72,6 @@ func (sc *SwimmersController) BenchmarkTime(res http.ResponseWriter, req *http.R
 			continue
 		}
 
-		// Find standard times in the database.
 		standardTimeExample := StandardTime{
 			Age:          searchAge,
 			Gender:       gender,

--- a/swimmers/repository.go
+++ b/swimmers/repository.go
@@ -5,18 +5,17 @@ import (
 	"geekswimmers/storage"
 )
 
-func FindChampionshipMeets(course string, db storage.Database) ([]*Meet, error) {
-	stmt := `select m.name, m.age_date, m.time_standard, ss.id, ss.name, 
+func FindChampionshipMeets(db storage.Database) ([]*Meet, error) {
+	stmt := `select m.name, m.age_date, m.time_standard, m.course, ss.id, ss.name, 
 	                ts.min_age_time, ts.max_age_time, m.min_age_enforced, m.max_age_enforced
 			 from meet m
 			 join swim_season ss on ss.id = m.season
 			 join time_standard ts on ts.id = m.time_standard
-			 where course = $1 
-			 	and ss.start_date <= now() and ss.end_date >= now()
+			 where ss.start_date <= now() and ss.end_date >= now()
 			 	and m.time_standard is not null 
 				and m.age_date is not null
 			 order by m.age_date`
-	rows, err := db.Query(context.Background(), stmt, course)
+	rows, err := db.Query(context.Background(), stmt)
 	if err != nil {
 		return nil, err
 	}
@@ -24,10 +23,8 @@ func FindChampionshipMeets(course string, db storage.Database) ([]*Meet, error) 
 
 	var meets []*Meet
 	for rows.Next() {
-		meet := &Meet{
-			Course: course,
-		}
-		err = rows.Scan(&meet.Name, &meet.AgeDate, &meet.TimeStandard.ID, &meet.Season.ID, &meet.Season.Name,
+		meet := &Meet{}
+		err = rows.Scan(&meet.Name, &meet.AgeDate, &meet.TimeStandard.ID, &meet.Course, &meet.Season.ID, &meet.Season.Name,
 			&meet.TimeStandard.MinAgeTime, &meet.TimeStandard.MaxAgeTime, &meet.MinAgeEnforced, &meet.MaxAgeEnforced)
 
 		if err != nil {

--- a/web/templates/page.benchmark.html
+++ b/web/templates/page.benchmark.html
@@ -24,7 +24,7 @@
                     </div>
                 </p>
                 <p class="card-text">
-                    The standard to qualify a {{.Age}}-year-old to <b>{{$.Page.Distance}} {{$.Page.Stroke | Title}}</b>
+                    The {{if eq $.Page.Course "SHORT"}}short course{{end}}{{if eq $.Page.Course "LONG"}}long course{{end}} standard to qualify a {{.Age}}-year-old to <b>{{$.Page.Distance}} {{$.Page.Stroke | Title}}</b>
                     at this meet is <b>{{.StandardTime.Standard | FormatMiliseconds}}</b>.
                     {{if (gt .StandardTime.Difference 0)}}
                         It missed the standard by <b>{{.StandardTime.Difference | FormatMiliseconds}}</b>.


### PR DESCRIPTION
For the majority of the championships, short and long course standards can be used to qualify for short and long course championships. There is no need to convert times because the standard already publishes their short and long course expectations.

I understood that they only convert times of longer distances and use it as seed times to organize the heats.